### PR TITLE
Fix remoteName() to prefer origin remote

### DIFF
--- a/src/Helpers/Git.php
+++ b/src/Helpers/Git.php
@@ -150,8 +150,14 @@ Class Git
     {
         $flag = self::repoFlag($repo_dir);
         $remotes = Shell::run("git $flag remote 2>/dev/null");
-        $remotearray = explode(PHP_EOL, $remotes);
-        return array_shift($remotearray);
+        $remotearray = array_filter(array_map('trim', explode(PHP_EOL, $remotes)));
+
+        // Prefer 'origin' when multiple remotes exist
+        if (in_array('origin', $remotearray, true)) {
+            return 'origin';
+        }
+
+        return reset($remotearray) ?: 'origin';
     }
 
     /**


### PR DESCRIPTION
## Summary

- `Git::remoteName()` picked the first remote alphabetically from `git remote`, which could be a non-primary remote (e.g. `launchpad` before `origin`)
- This caused `deploy:push` to update GitHub variables on the wrong repository — variable was set on `merchantprotocol/launchpad` instead of `dataripple-org/ghostagent`
- Now prefers `origin` when it exists, falling back to the first remote otherwise

## Test plan

- [x] Verified `protocol deploy:push v0.1.8` on a repo with multiple remotes (`launchpad` + `origin`) — correctly targets `origin`
- [ ] Verify single-remote repos still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)