### PR TITLE
Fix Git::remoteName() to prefer origin remote

### DIFF
--- a/src/Helpers/Git.php
+++ b/src/Helpers/Git.php
@@ -150,7 +150,10 @@ Class Git
     {
         $flag = self::repoFlag($repo_dir);
         $remotes = Shell::run("git $flag remote 2>/dev/null");
-        $remotearray = explode(PHP_EOL, $remotes);
+        $remotearray = array_filter(explode(PHP_EOL, $remotes));
+        if (in_array('origin', $remotearray)) {
+            return 'origin';
+        }
         return array_shift($remotearray);
     }
 


### PR DESCRIPTION
## Summary
- `Git::remoteName()` now returns `origin` when it exists, instead of the first remote alphabetically
- Fixes releases pushing to the wrong remote (e.g. `launchpad` instead of `origin`) in repos with multiple remotes

## Test plan
- [ ] Verify `protocol release:create` pushes to `origin` in repos with multiple remotes

🤖 Generated with [Claude Code](https://claude.com/claude-code)